### PR TITLE
fix: go-test migration to new release

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,11 +5,12 @@ on:
     types: [ opened, synchronize, reopened ]
 permissions:
   contents: read
+  pull-requests: write
+  packages: write
 jobs:
   test:
-    uses: netcracker/qubership-core-infra/.github/workflows/go-build-with-sonar.yaml@e7c8933e41d7e732f6f1f77dab34441d093c5577 # v2.1.0
+    uses: Netcracker/qubership-core-infra/.github/workflows/generic-go-build.yaml@bc2a0bd082147e23b4091616c608a21cc2957728 # v2.4.1
     with:
-      actor: ${{ github.actor }}
       sonar-project-key: ${{ vars.SONAR_PROJECT_KEY }}
-    secrets:
-      sonar-token: ${{ secrets.SONAR_TOKEN }}
+      skip-docker: true
+    secrets: inherit


### PR DESCRIPTION
Migrate go-test workflow to new release version